### PR TITLE
changed libname

### DIFF
--- a/libssh2.nim
+++ b/libssh2.nim
@@ -10,7 +10,7 @@ elif defined(macosx):
     libname = "libssh2.1.dylib"
 elif defined(unix):
   const
-    libname = "libssh2.so"
+    libname = "libssh2.so.1"
 
 {.pragma: ssh2,
   cdecl,


### PR DESCRIPTION
Hi.
Maybe need change?
Did I do something wrong?

ubuntu 16.04.02 LTS
libssh2.so: cannot open shared object file: No such file or directory  could not load: libssh2.so
/usr/lib/x86_64-linux-gnu/libssh2.so -->> /usr/lib/x86_64-linux-gnu/libssh2.so.1
