### PR TITLE
revert breaking change in session_last_error proc

### DIFF
--- a/libssh2.nim
+++ b/libssh2.nim
@@ -509,7 +509,7 @@ proc publickey_remove*(p: PublicKey, name, blob: cstring, blobLen: int): cint {.
 
 proc publickey_shutdown*(p: PublicKey): cint {.ssh2.}
 
-proc scp_recv*(s: Session, path: cstring, sb: Stat) {.ssh2.}
+proc scp_recv*(s: Session, path: cstring, sb: Stat): Channel {.ssh2.}
 
 proc scp_send_ex*(s: Session, path: cstring, mode, size: int, mtime, atime: int64): Channel {.ssh2.}
 

--- a/libssh2.nim
+++ b/libssh2.nim
@@ -558,7 +558,7 @@ proc session_init*(): Session =
 
 proc session_last_errno*(s: Session): cint {.ssh2.}
 
-proc session_last_error*(s: Session, errormsg: ptr cstring, errmsgLene, wantBuf: int): cint {.ssh2.}
+proc session_last_error*(s: Session, errormsg: ptr cstring, errmsgLen: ptr cint, wantBuf: int): cint {.ssh2.}
 
 proc session_method_pref*(s: Session, methodType: int, prefs: cstring): cint {.ssh2.}
 

--- a/libssh2.nimble
+++ b/libssh2.nimble
@@ -1,6 +1,6 @@
 [Package]
 name          = "libssh2"
-version       = "0.1.5"
+version       = "0.1.6"
 author        = "Huy Doan"
 description   = "Nim wrapper for libssh2"
 license       = "MIT"


### PR DESCRIPTION
`errmsgLen` parameter was renamed `errmsgLene` (maybe by mistake) and the object type declaration was removed.
This change reverts back so the parameter is named `errmsgLen` with a `ptr cint` type

Also, the `scp_recv` proc, when called in the ssh2 package needs to return a channel type object. I have added this return type to the `scp_recv` proc